### PR TITLE
Make writing voice user-configurable instead of hardcoding a personal style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ my-paper/
 
 - **Stats stack.** R (ggplot, fixest, modelsummary). Stata/Python users: fork.
 - **Manuscript format.** LaTeX. Quarto users: `mstack-init --quarto`. Word: out of scope.
-- **Voice.** `digiuseppe-writing-style` is the default in `/draft-section`. Override per-paper in `.mstack/config.yaml`.
+- **Voice.** `/draft-section` and `/abstract-shotgun` anchor tone to whatever skill name you put in `voice.writing_style` in `.mstack/config.yaml`. MStack does not ship a personal style — install or author your own writing-style skill and point the config at it. If left empty, a generic academic voice is used.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,33 @@ Originally built for political science / international political economy work, b
 
 ## Install
 
+MStack ships as a single-plugin Claude Code marketplace. The slash-command install path works identically across the **CLI**, the **desktop app** (Mac/Windows), the **web app** at claude.ai/code, and the **IDE extensions** (VS Code, JetBrains).
+
+### Recommended: install as a plugin (all interfaces)
+
+In any Claude Code session, run:
+
+```text
+/plugin marketplace add matthewdigiuseppe/MStack
+/plugin install mstack@mstack
+```
+
+That registers MStack's marketplace and installs the plugin. The 34 slash commands (`/research-question`, `/draft-section`, …) become available immediately. You can also browse and manage MStack from `/plugin` (Discover / Installed / Marketplaces tabs).
+
+To scaffold a new paper folder from a Claude Code session, ask Claude to run the bundled `mstack-init` script — its path is `${CLAUDE_PLUGIN_ROOT}/bin/mstack-init <paper-name>` once the plugin is installed.
+
+### Optional: manual install (CLI / desktop, puts `mstack-init` on shell PATH)
+
+If you'd rather run `mstack-init` directly from your terminal without going through Claude Code, clone and run `./setup`:
+
 ```bash
 git clone --single-branch --depth 1 https://github.com/matthewdigiuseppe/MStack.git ~/.claude/plugins/mstack \
   && cd ~/.claude/plugins/mstack && ./setup
 ```
 
-Then run `mstack-init my-paper` in any directory to scaffold a new paper folder.
+`./setup` symlinks the plugin into `~/.claude/skills/mstack` and prints a one-line export to add `bin/` to your `PATH`. Then `mstack-init my-paper` works from any directory.
+
+This path is for local shells only — on Claude Code on the web there is no persistent shell to add to, so use the plugin install above instead.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -8,33 +8,40 @@ Originally built for political science / international political economy work, b
 
 ## Install
 
-MStack ships as a single-plugin Claude Code marketplace. The slash-command install path works identically across the **CLI**, the **desktop app** (Mac/Windows), the **web app** at claude.ai/code, and the **IDE extensions** (VS Code, JetBrains).
+MStack works in every flavor of Claude Code: the **terminal CLI**, the **Mac and Windows desktop apps**, **Claude Code on the web** (claude.ai/code), and the **VS Code and JetBrains extensions**. The steps below are the same in all of them.
 
-### Recommended: install as a plugin (all interfaces)
+### Step 1 — Add MStack to Claude Code
 
-In any Claude Code session, run:
+Open Claude Code and type these two lines, one at a time, into the chat box:
 
-```text
+```
 /plugin marketplace add matthewdigiuseppe/MStack
 /plugin install mstack@mstack
 ```
 
-That registers MStack's marketplace and installs the plugin. The 34 slash commands (`/research-question`, `/draft-section`, …) become available immediately. You can also browse and manage MStack from `/plugin` (Discover / Installed / Marketplaces tabs).
+The first line tells Claude Code where to find MStack. The second line installs it. When both are done, all 34 MStack commands — `/research-question`, `/draft-section`, and so on — are ready to use. You can see what's installed anytime by typing `/plugin`.
 
-To scaffold a new paper folder from a Claude Code session, ask Claude to run the bundled `mstack-init` script — its path is `${CLAUDE_PLUGIN_ROOT}/bin/mstack-init <paper-name>` once the plugin is installed.
+### Step 2 — Start a new paper
 
-### Optional: manual install (CLI / desktop, puts `mstack-init` on shell PATH)
+In Claude Code, just ask in plain English:
 
-If you'd rather run `mstack-init` directly from your terminal without going through Claude Code, clone and run `./setup`:
+> Please run `mstack-init tariffs-aid` to set up a new MStack paper folder here.
+
+(Replace `tariffs-aid` with a short name for your paper.) Claude will create the folder with everything in the right place. Then open the file `.mstack/config.yaml` inside it and fill in your name, the paper title, and your target journals.
+
+You're done. From here you'd typically start with `/research-question` or `/idea-shotgun`.
+
+### Power-user alternative (optional, terminal users only)
+
+If you live in a Mac or Linux terminal and would rather run `mstack-init` directly from the command line instead of asking Claude, you can clone MStack manually:
 
 ```bash
-git clone --single-branch --depth 1 https://github.com/matthewdigiuseppe/MStack.git ~/.claude/plugins/mstack \
-  && cd ~/.claude/plugins/mstack && ./setup
+git clone https://github.com/matthewdigiuseppe/MStack.git ~/.claude/plugins/mstack
+cd ~/.claude/plugins/mstack
+./setup
 ```
 
-`./setup` symlinks the plugin into `~/.claude/skills/mstack` and prints a one-line export to add `bin/` to your `PATH`. Then `mstack-init my-paper` works from any directory.
-
-This path is for local shells only — on Claude Code on the web there is no persistent shell to add to, so use the plugin install above instead.
+`./setup` registers MStack with Claude Code and prints one line for you to paste into your shell config so that typing `mstack-init my-paper` in any folder will work. Skip this whole section if you already installed via `/plugin install` above — it does the same job.
 
 ## Workflow
 

--- a/bin/mstack-init
+++ b/bin/mstack-init
@@ -68,7 +68,7 @@ if [[ "$USE_QUARTO" == "1" ]]; then
     cat > "$DEST/paper/main.qmd" <<'QMD'
 ---
 title: "TITLE"
-author: "Matt DiGiuseppe"
+author: "AUTHOR"
 format:
   pdf:
     documentclass: article

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -27,7 +27,7 @@ Every skill carries a **stage** and a **voice**. Stage tells you when to use it.
 
 - **Advisor / adversarial-advisor** voices are for early stages (ideate, scope-challenge). Their job is to talk you out of bad ideas.
 - **Methodologist** voice runs through map, design, and analysis. Its job is to make the inference defensible.
-- **Writer** voice owns the writing stage and defers to `digiuseppe-writing-style` for tone.
+- **Writer** voice owns the writing stage and defers to the user-configured writing-style skill (`.mstack/config.yaml` → `voice.writing_style`) for tone.
 - **Referee** voice (`/referee-mock`) defers to `journal-reviewer-style` and front-runs the actual reviewers.
 - **Replicator** voice closes the project (`/archive`) and asks: would a stranger rebuild every table from raw data?
 
@@ -35,7 +35,7 @@ Every skill carries a **stage** and a **voice**. Stage tells you when to use it.
 
 - **Stats stack:** R. Regenerate from `data/raw/` via numbered scripts in `code/`. Stata or Python users will need to fork or override.
 - **Manuscript format:** LaTeX by default; `mstack-init --quarto` for Quarto.
-- **Writing voice:** `digiuseppe-writing-style`. Override per-paper in `.mstack/config.yaml`.
+- **Writing voice:** user-configurable. Set `voice.writing_style` in `.mstack/config.yaml` to the name of a writing-style skill you've installed. MStack does not ship one; leave it empty to use a generic academic voice.
 - **Reviewer voice:** `journal-reviewer-style`.
 - **Survey work:** layered with `agent-disclosure` for AI-completion defenses.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -49,7 +49,7 @@ Each skill is invokable as `/<name>` once the plugin is installed. Stages match 
 
 | Skill | Voice | Use when |
 |---|---|---|
-| `/draft-section <name>` | writer | Drafting any section. Wraps `digiuseppe-writing-style`. |
+| `/draft-section <name>` | writer | Drafting any section. Anchors to the writing-style skill named in `.mstack/config.yaml` (`voice.writing_style`); falls back to a generic academic voice if unset. |
 | `/abstract-shotgun` | writer | After complete draft. 4–6 abstract variants with positioning differences. |
 | `/title-shotgun` | writer | Late-stage. Title options ranked on hook × precision. |
 | `/coauthor-review` | coauthor | On a complete draft. Configurable persona. |

--- a/skills/abstract-shotgun/SKILL.md
+++ b/skills/abstract-shotgun/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
 # /mstack:abstract-shotgun
 
 **Stage:** write
-**Voice:** writer (anchored to `digiuseppe-writing-style`)
+**Voice:** writer (anchored to the skill named in `.mstack/config.yaml` → `voice.writing_style`)
 
 ## When to invoke
 
@@ -21,7 +21,7 @@ The full draft exists. The abstract is the single hardest paragraph in the paper
 
 1. **Load.** `paper/sections/intro.tex`, `paper/sections/discussion.tex`, `paper/sections/results.tex`, `.mstack/config.yaml` (target journals).
 
-2. **Use digiuseppe-writing-style** for voice across all variants.
+2. **Apply the configured writing voice** across all variants. Read `voice.writing_style` from `.mstack/config.yaml`; if set, invoke that skill. If unset, default to a clean, generic academic voice (short sentences, active verbs, no hedge-stuffing).
 
 3. **Generate 4–6 variants**, each varying along one of:
 

--- a/skills/draft-section/SKILL.md
+++ b/skills/draft-section/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draft-section
-description: Drafts a paper section (intro, theory, data, methods, results, discussion, abstract) in voice. Wraps the digiuseppe-writing-style skill. Section name passed as argument. Writes to paper/sections/<name>.tex. Never fabricates citations.
+description: Drafts a paper section (intro, theory, data, methods, results, discussion, abstract) in voice. Anchors tone to the writing-style skill named in `.mstack/config.yaml` (`voice.writing_style`); falls back to a generic academic voice if unset. Section name passed as argument. Writes to paper/sections/<name>.tex. Never fabricates citations.
 user-invocable: true
 allowed-tools:
   - Read
@@ -14,7 +14,7 @@ allowed-tools:
 # /mstack:draft-section
 
 **Stage:** write
-**Voice:** writer (anchored to `digiuseppe-writing-style`)
+**Voice:** writer (anchored to the skill named in `.mstack/config.yaml` → `voice.writing_style`)
 
 ## When to invoke
 
@@ -36,8 +36,9 @@ If not supplied or unrecognized, list the recognized names and stop.
    - For methods/results: read `code/02-analyze.R`, `output/tables/*`, `output/figures/*`. The numbers in your prose must match the tables on disk.
 
 2. **Invoke the writing-style skill.**
-   - Use the **digiuseppe-writing-style** skill for tone, sentence rhythm, and vocabulary.
-   - If `.mstack/config.yaml` overrides `voice.writing_style`, honor that instead.
+   - Read `voice.writing_style` from `.mstack/config.yaml`.
+   - If set, invoke that skill for tone, sentence rhythm, and vocabulary.
+   - If unset or empty, write in a clean, generic academic voice: short sentences, active verbs where possible, no hedge-stuffing, no thesaurus reaches. Tell the user once that no `voice.writing_style` is configured and they can set one in `.mstack/config.yaml`.
 
 3. **Draft the section** with the section-specific bar:
 
@@ -69,7 +70,7 @@ If not supplied or unrecognized, list the recognized names and stop.
 
 - **Fabricating citations.** Mark missing refs as TODOs; never invent.
 - **Drafting `results` before `02-analyze.R` has stable output.** If tables/figures are missing, stop and tell the user to run `/analyze` first.
-- **Writing in a generic academic voice** when `digiuseppe-writing-style` is loaded. Defer to it; do not paper over it with hedge phrases.
+- **Writing in a generic academic voice** when a `voice.writing_style` skill is configured and loaded. Defer to it; do not paper over it with hedge phrases.
 - **Filling space.** A short, sharp section beats a long, hedging one.
 
 ## When to call other skills

--- a/templates/paper-folder/.mstack/config.yaml
+++ b/templates/paper-folder/.mstack/config.yaml
@@ -8,7 +8,7 @@ paper:
   status: "ideating"       # ideating | mapping | designing | building | analyzing | writing | submitted | r-and-r | accepted | archived
 
 authors:
-  - name: "Matt DiGiuseppe"
+  - name: ""               # your name
     role: "lead"
   # - name: "Coauthor Name"
   #   role: "coauthor"
@@ -33,6 +33,8 @@ decisions:
   # - "2026-05-09: dropped 2008-2010 from sample due to crisis confound."
 
 voice:
-  # Override defaults for this paper if needed.
-  writing_style: "digiuseppe-writing-style"
+  # Name of a Claude Code skill that defines your prose voice (tone, rhythm,
+  # vocabulary). MStack does not ship one — install or author your own and put
+  # its skill name here. Leave empty to use a generic academic voice.
+  writing_style: ""
   reviewer_style: "journal-reviewer-style"

--- a/templates/paper-folder/paper/main.tex
+++ b/templates/paper-folder/paper/main.tex
@@ -11,7 +11,7 @@
 \doublespacing
 
 \title{TITLE}
-\author{Matt DiGiuseppe}
+\author{AUTHOR}
 \date{\today}
 
 \begin{document}


### PR DESCRIPTION
`/draft-section` and `/abstract-shotgun` now read `voice.writing_style` from
.mstack/config.yaml and invoke whatever skill the user names there, falling
back to a generic academic voice if unset. Template author fields and config
defaults are placeholders so MStack ships without a personal style baked in.

https://claude.ai/code/session_01E1kXKkdDxP7pyA9ynow21g