### PR TITLE
Default power-analysis skill to DeclareDesign

### DIFF
--- a/skills/power-analysis/SKILL.md
+++ b/skills/power-analysis/SKILL.md
@@ -32,8 +32,8 @@ After `/design-research` chooses a design. Before fielding. The prereg's "Sample
    - **Design constants** — clustering, ICC, attrition rate, blocking.
 
 3. **Write `code/00-power.R`** that:
-   - Loads `pwr`, or `DeclareDesign`, or `Superpower` depending on the design.
-   - Implements either an analytic formula (simple cases) or simulation (FE, panel, hierarchical, conjoint).
+   - **Defaults to `DeclareDesign`** (https://declaredesign.org/r/declaredesign/) — declare the model, inquiry, data strategy, and answer strategy, then `diagnose_design()` over a grid of N and effect sizes. This is the default because it generalizes across experimental, survey, FE, panel, hierarchical, and conjoint designs, and forces the design assumptions to be made explicit.
+   - Use `pwr` only as a quick analytic sanity check for textbook cases (two-sample t-test, single-level proportion). Use `Superpower` only for factorial ANOVA designs where DeclareDesign would be overkill. Note the fallback choice and its justification in the script header.
    - For experiments / surveys: report N for power = 0.80 *and* MDE at the user's planned N.
    - For observational with FE: simulate to find effective N for identification.
    - Saves a sensitivity curve (power vs. effect size; MDE vs. N) to `output/figures/power-sensitivity.pdf`.
@@ -61,6 +61,7 @@ After `/design-research` chooses a design. Before fielding. The prereg's "Sample
 - **Power calc on the wrong effect size.** Using the published median effect from a literature with publication bias inflates expected effect and underpowers the study.
 - **Black-box defaults.** Justify ICC, attrition, clustering — every assumption changes the answer.
 - **Skipping the sensitivity curve.** A single number for power is not informative; the curve is.
+- **Reaching for `pwr` first.** Default to DeclareDesign so the model, inquiry, data strategy, and answer strategy are explicit. Falling back to `pwr` is allowed only when the design is genuinely a textbook two-sample case and the script header documents why.
 
 ## When to call other skills
 


### PR DESCRIPTION
## Summary

- Make [DeclareDesign](https://declaredesign.org/r/declaredesign/) the default backend for the `/power-analysis` skill, replacing the prior "pick one of pwr / DeclareDesign / Superpower" language.
- Keep `pwr` and `Superpower` as documented fallbacks for textbook two-sample and factorial-ANOVA cases respectively.
- Add an anti-pattern entry against reaching for `pwr` first.

## Why

DeclareDesign generalizes across the experimental, survey, FE, panel, hierarchical, and conjoint designs this skill is meant to handle, and it forces the model / inquiry / data strategy / answer strategy to be made explicit — exactly the discipline a methodologist-voice skill should impose. The prior wording let the script silently default to a simpler analytic tool and skip that step.

## What changed

- [skills/power-analysis/SKILL.md](skills/power-analysis/SKILL.md): rewrote the "Write `code/00-power.R`" bullet to default to DeclareDesign and bound the fallbacks; added an anti-pattern.

## Reviewer notes

- No code path changes — this skill writes R code at runtime; behavior changes only on next `/power-analysis` invocation.
- Users without `DeclareDesign` installed will hit a load error on first use; that's intentional under the new defaults. If we want a softer landing, a follow-up could have the skill check for the package and prompt to install.

## Test plan

- [ ] Run `/power-analysis` on a paper with a simple experiment and confirm the generated `code/00-power.R` uses `DeclareDesign` by default.
- [ ] Confirm fallback path: ask for a two-sample t-test power calc and confirm the script header documents the `pwr` fallback choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)